### PR TITLE
error when sending email-attachments from model account.invoice

### DIFF
--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -108,8 +108,9 @@ class Report(object):
         Add attachment for this report
         """
         name = aname + '.' + self.outputFormat
-        context['type'] ='binary'
-        context['default_type'] ='binary'
+        ctx = context.copy()
+        ctx['type'] ='binary'
+        ctx['default_type'] ='binary'
         
         return self.pool.get('ir.attachment').create(self.cr, self.uid, {
                     'name': aname,
@@ -117,7 +118,7 @@ class Report(object):
                     'datas_fname': name,
                     'res_model': self.model,
                     'res_id': id,
-                    }, context=context
+                    }, context=ctx
         )
 
     def _jasper_execute(self, ex, current_document, js_conf, pdf_list, reload=False,

--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -108,6 +108,9 @@ class Report(object):
         Add attachment for this report
         """
         name = aname + '.' + self.outputFormat
+        context['type'] ='binary'
+        context['default_type'] ='binary'
+        
         return self.pool.get('ir.attachment').create(self.cr, self.uid, {
                     'name': aname,
                     'datas': base64.encodestring(content),


### PR DESCRIPTION
When defining a report from model account.invoice and using the button "Send by Mail" I get this error message:

'The value "out_invoice" for the field "ir_attachment.type" is not in the selection'.
